### PR TITLE
Apigee Company Administration

### DIFF
--- a/apigee_nonmint_company/apigee_nonmint_company.module
+++ b/apigee_nonmint_company/apigee_nonmint_company.module
@@ -11,9 +11,11 @@ include_once 'apigee_nonmint_company.features.inc';
 function apigee_nonmint_company_permission() {
   $permissions = array();
 
+  // Note: This displays a list of companies, but in order to manage companies
+  // in the list, you will need manage permissions from apigee_company as well.
   $permissions['manage all companies'] = array(
     'title' => t('Manage all companies'),
-    'description' => t('Invite, remove and manage roles for all companies.'),
+    'description' => t('Display admin list all companies.'),
   );
   return $permissions;
 }

--- a/apigee_nonmint_company/apigee_nonmint_company.module
+++ b/apigee_nonmint_company/apigee_nonmint_company.module
@@ -6,6 +6,36 @@
 include_once 'apigee_nonmint_company.features.inc';
 
 /**
+ * Implements hook_permission().
+ */
+function apigee_nonmint_company_permission() {
+  $permissions = array();
+
+  $permissions['manage all companies'] = array(
+    'title' => t('Manage all companies'),
+    'description' => t('Invite, remove and manage roles for all companies.'),
+  );
+  return $permissions;
+}
+
+/**
+ * Implements hook_menu().
+ */
+function apigee_nonmint_company_menu() {
+  $items = array();
+
+  $items['admin/content/companies'] = array(
+    'title' => 'Companies',
+    'description' => 'Manage all companies.',
+    'access arguments' => array('manage all companies'),
+    'page callback' => 'apigee_nonmint_company_all_companies',
+    'type' => MENU_NORMAL_ITEM,
+  );
+
+  return $items;
+}
+
+/**
  * Implements hook_entity_info_alter
  *
  * Overwrite the apigee_company_invitation controller with the custom entity
@@ -174,3 +204,41 @@ function apigee_nonmint_company_theme_registry_alter(&$theme_registry) {
   }
 
 }
+
+/**
+ * Utility function that returns and indexed array of all company objects.
+ *
+ * @param array $company_ids
+ *   An indexed array of company machine names.
+ *
+ * @return array
+ *   An array of company entities.
+ */
+function apigee_nonmint_company_get_all_company_objects() {
+  $company_list = entity_load('apigee_company');
+  return $company_list;
+}
+
+/**
+ * Get a themed list of all companies.
+ *
+ * @global object $user
+ *
+ * @return string
+ *   Themed html for the company list and invitations.
+ */
+function apigee_nonmint_company_all_companies() {
+  $items_per_page = variable_get('apigee_nonmint_company_items_per_page', 20);
+  $company_objects = apigee_nonmint_company_get_all_company_objects();
+  $items_total = count($company_objects);
+
+  $current_page = pager_default_initialize($items_total, $items_per_page);
+  // Querying for a subset would require circumventing or modifying the SDK
+  // so we return everything and then slice to keep the UI manageable.
+  $company_objects = array_slice($company_objects, ($current_page * $items_per_page), $items_per_page);
+
+  $output = theme('apigee_company_developer_companies', array('companies' => $company_objects));
+  $output .= theme('pager', array('quantity' => $items_total));
+  return $output;
+}
+


### PR DESCRIPTION
This adds an Apigee company administration screen.

There are a few shortcomings that should be resolved at some point:
a) This relies on apigee_company for the form display. While this is good - and perhaps even preferred - the apigee_company module never anticipates companies that you are a not a member of to display in the list. As a result, companies you are not an owner of show a "Leave" link regardless of whether you are a member or not. This is misleading, but should likely be resolved at the apigee_company level.
b) The form and the actual administration are divorced. Right now, the new permission allows for the entire company list to display in the administration which is useful, however, it provides no power over actual _administration_ of those companies. In effect, this provides a list of paginated companies, but fails to actually allow you to administer those companies without additional permissions. This could be resolved here but more likely this would be a permission that fits better at the apigee_company level that we could tap into here (or the administration could be moved there)
c) It's not (easily) possible to retrieve only a partial list of companies. The SDK allows you to retrieve either a single company or all companies. Ideally, we would be able to retrieve one "page" of companies at a time, know the overall count of companies, and request new data sets as we traverse between pages. Because this is not possible, we "fake" pagination by retrieving the data set and then slicing up the data into parts for display. This is useful from an administrator perspective to keep the UI from being overwhelming but not helpful in that we are doing extra work (array manipulation) with little gain (we already retrieved all the data). This is somewhat mitigated by the caching mechanisms in place, but it seems like a fix in the PHP SDK might be preferred.